### PR TITLE
fix(vold): use correct i.MX95 USB controller address in fstab

### DIFF
--- a/patches/imx-android-15.0.0_1.0.0/android_build/lec-imx95/device/nxp/0001-lec-imx95-add-device-support.patch
+++ b/patches/imx-android-15.0.0_1.0.0/android_build/lec-imx95/device/nxp/0001-lec-imx95-add-device-support.patch
@@ -1297,7 +1297,7 @@ index 00000000..d9a04f66
 +# The filesystem that contains the filesystem checker binary (typically /system) cannot
 +# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 +
-+/devices/platform/soc/4c200000.usb/*        auto auto defaults voldmanaged=usb:auto
++/devices/platform/soc/4c010010.usb/*        auto auto defaults voldmanaged=usb:auto
 +/dev/block/by-name/userdata    /data        f2fs    nodev,noatime,nosuid,inlinecrypt,reserve_root=32768 latemount,wait,check,quota,formattable,fileencryption=aes-256-xts,fscompress,keydirectory=/metadata/vold/metadata_encryption,checkpoint=fs
 +/dev/block/by-name/metadata    /metadata    f2fs    noatime,nosuid,nodev,discard,sync,fsync_mode=nobarrier                           wait,formattable,first_stage_mount,check
 +/dev/block/by-name/misc        /misc        emmc    defaults                                                                         defaults


### PR DESCRIPTION
Replace incorrect USB controller path with 4c010010.usb to allow vold to detect and automatically mount USB mass storage devices.
<img width="785" height="76" alt="sysfs-usb" src="https://github.com/user-attachments/assets/2702895f-a6b9-4ffd-a998-17ac593d9394" />
